### PR TITLE
Add test environment support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Flutter",
+            "program": "lib/main.dart",
+            "request": "launch",
+            "type": "dart"
+        }
+    ]
+}

--- a/android/src/main/java/in/appyflow/paytm/PaytmPlugin.java
+++ b/android/src/main/java/in/appyflow/paytm/PaytmPlugin.java
@@ -94,17 +94,27 @@ public class PaytmPlugin implements FlutterPlugin, MethodCallHandler, PluginRegi
             String orderId = call.argument("orderId").toString();
             String txnToken = call.argument("txnToken").toString();
             String txnAmount = call.argument("txnAmount").toString();
-            String callBackUrl = call.argument("callBackUrl").toString();
-            beginPayment(mId, orderId, txnToken, txnAmount, callBackUrl);
+            String callbackUrl = call.argument("callBackUrl").toString();
+            boolean isStaging = (Boolean) call.argument("isStaging");
+            beginPayment(mId, orderId, txnToken, txnAmount, callbackUrl, isStaging);
         } else {
             result.notImplemented();
         }
     }
 
-    private void beginPayment(String mId, String orderId, String txnToken, String txnAmount, String callBackUrl) {
+    private void beginPayment(String mId, String orderId, String txnToken, String txnAmount, String callbackUrl, boolean isStaging) {
+        String host = "https://securegw.paytm.in/";
+        if (isStaging) {
+            host = "https://securegw-stage.paytm.in/";
+        }
+        String callback = null;
+        if (callbackUrl == null || callbackUrl.trim().isEmpty()) {
+            callback = host + "theia/paytmCallback?ORDER_ID=" + orderId;
+        } else {
+            callback = callbackUrl;
+        }
 
-
-        PaytmOrder paytmOrder = new PaytmOrder(orderId, mId, txnToken, txnAmount, callBackUrl);
+        PaytmOrder paytmOrder = new PaytmOrder(orderId, mId, txnToken, txnAmount, callback);
 
         Log.i(TAG, paytmOrder.toString());
 
@@ -212,7 +222,7 @@ public class PaytmPlugin implements FlutterPlugin, MethodCallHandler, PluginRegi
 
         });
 
-
+        transactionManager.setShowPaymentUrl(host + "theia/api/v1/showPaymentPage");
         transactionManager.startTransaction(activity, PAYTM_REQUEST_CODE);
 
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -149,8 +149,10 @@ class _MyAppState extends State<MyApp> {
     });
     String orderId = DateTime.now().millisecondsSinceEpoch.toString();
 
-    String callBackUrl =
-        'https://securegw.paytm.in/theia/paytmCallback?ORDER_ID=' + orderId;
+    String callBackUrl = (false
+            ? 'https://securegw.paytm.in/theia/paytmCallback?ORDER_ID='
+            : 'https://securegw-stage.paytm.in/theia/paytmCallback?ORDER_ID=') +
+        orderId;
 
     var url =
         'https://desolate-anchorage-29312.herokuapp.com/generateTxnToken' +
@@ -186,6 +188,7 @@ class _MyAppState extends State<MyApp> {
       txnToken,
       amount.toString(),
       callBackUrl,
+      true,
     );
 
     paytmResponse.then((value) {

--- a/lib/paytm.dart
+++ b/lib/paytm.dart
@@ -11,6 +11,7 @@ class Paytm {
     String txnToken,
     String txnAmount,
     String callBackUrl,
+    bool isStaging,
   ) async {
     assert(mId != null);
     assert(orderId != null);
@@ -25,6 +26,7 @@ class Paytm {
       'txnToken': txnToken,
       'txnAmount': txnAmount,
       'callBackUrl': callBackUrl,
+      'isStaging': isStaging,
     });
 
     return response;


### PR DESCRIPTION
This enables usage of payTM Test API with this plugin. 
To use test API, just set the `isStaging` in `payWithPaytm` to `true`.  
Note: Make sure to use staging environment API key and Merchant ID when doing this. 